### PR TITLE
Optparse

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -5562,7 +5562,6 @@ def main():
     # General runtime configuration
     global LOAD_PATHS, VERBOSITY, STATIC_ROOT, ASSETS_ROOT
     VERBOSITY = 0
-    load_paths = [p.strip() for p in LOAD_PATHS.split(',')]
 
     if options.time:
         VERBOSITY = 2
@@ -5571,11 +5570,12 @@ def main():
     if options.assets_root is not None:
         ASSETS_ROOT = options.assets_root
     if options.load_path is not None:
+        load_paths = [p.strip() for p in LOAD_PATHS.split(',')]
         for p in options.load_path.replace(';', ',').split(','):
             p = p.strip()
             if p and p not in load_paths:
                 load_paths.append(p)
-    LOAD_PATHS = ','.join(load_paths)
+        LOAD_PATHS = ','.join(load_paths)
 
     # Execution modes
     if options.test:


### PR DESCRIPTION
Hi, I just ran across pyScss yesterday, and it looks great!

I've always found getopt to be a little cryptic compared to optparse, so I took the liberty of converting pyScss from one to the other.

In the process, I also:
1. Slightly reformatted the help output to group `--load-path`, `--static-root`, and `--assets-root` separately from the other options.
2. Stopped calling `sys.exit()` with an error for `--help` and `--version`, to match the standard behavior of other programs.
3. Only try to set up readline when it will be used (`--interactive`).
4. Stopped trying to open the filename in `--output` when it won't be used (`--version`, `--help`, or `--interactive`).
5. Stopped rebuilding LOAD_PATHS unless the user supplies an additional `--load-path`.

If you'd like me to refactor this pull request in any way, or if you'd like me to separately apply the above changes to the current getopt version, just let me know and I'll be happy to oblige.
