### PR TITLE
Add watch functionality

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -5734,16 +5734,16 @@ def main():
                 self.css.scss_opts['compress'] = options.compress
                 self.output = options.output
 
-            def valid(self, path):
+            def is_valid(self, path):
                 return os.path.isfile(path) and path.endswith(".scss") and not os.path.basename(path).startswith("_")
 
             def process(self, path):
                 if os.path.isdir(path):
                     for f in os.listdir(path):
                         full = os.path.join(path, f)
-                        if self.valid(full):
+                        if self.is_valid(full):
                             self.compile(full)
-                elif self.valid(path):
+                elif self.is_valid(path):
                     self.compile(path)
 
             def compile(self, src_path):


### PR DESCRIPTION
Issue #1 has been open for too long, so I finally went and did something about it. These commits should add watch functionality using the `watchdog` module. It's working strangely on my computer (OSX Lion) and only firing directory-changed events, rather than file-changed events, so when pyScss gets a directory-changed event from `watchdog`, it recompiles all the `.scss` files in the directory.
