### PR TITLE
WebKit Gradients and Unicode

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -972,7 +972,7 @@ class Scss(object):
                         m_vars.update(mixin[1])
                         m_codestr = mixin[2]
                         for i, a in enumerate(args):
-                            m_vars[m_params[i]] = str(a)
+                            m_vars[m_params[i]] = unicode(a)
                         m_vars.update(kwargs)
                         _options = rule[OPTIONS].copy()
                         _rule = spawn_rule(R, codestr=m_codestr, context=m_vars, options=_options, deps=set(), properties=[], final=False, lineno=c_lineno)
@@ -985,7 +985,7 @@ class Scss(object):
                 mixin = _mixin
             # Insert as many @mixin options as the default parameters:
             while len(new_params):
-                rule[OPTIONS][code + ' ' + funct + ':' + str(len(new_params))] = mixin
+                rule[OPTIONS][code + ' ' + funct + ':' + unicode(len(new_params))] = mixin
                 param = new_params.pop()
                 if param not in defaults:
                     break
@@ -1015,7 +1015,7 @@ class Scss(object):
                     num_args += 1
             if param:
                 new_params[varname] = param
-        mixin = rule[OPTIONS].get('@mixin ' + funct + ':' + str(num_args))
+        mixin = rule[OPTIONS].get('@mixin ' + funct + ':' + unicode(num_args))
         if not mixin:
             # Fallback to single parmeter:
             mixin = rule[OPTIONS].get('@mixin ' + funct + ':1')
@@ -1240,7 +1240,7 @@ class Scss(object):
 
             for i in rev(range(frm, through + 1)):
                 rule[CODESTR] = c_codestr
-                rule[CONTEXT][var] = str(i)
+                rule[CONTEXT][var] = unicode(i)
                 self.manage_children(rule, p_selectors, p_parents, p_children, scope, media)
 
     @print_timing(10)
@@ -1696,7 +1696,7 @@ class Scss(object):
         return __calculate_expr
 
     def do_glob_math(self, cont, context, options, rule, _dequote=False):
-        cont = str(cont)
+        cont = unicode(cont)
         if '#{' not in cont:
             return cont
         cont = _expr_glob_re.sub(self._calculate_expr(context, options, rule, _dequote), cont)
@@ -1757,7 +1757,7 @@ def to_str(num):
         return 'true' if num else 'false'
     elif num is None:
         return ''
-    return str(num)
+    return unicode(num)
 
 
 def to_float(num):
@@ -2614,12 +2614,12 @@ def _grid_image(left_gutter, width, right_gutter, height, columns=1, grid_color=
     if not inline:
         grid_name = 'grid_'
         if left_gutter:
-            grid_name += str(int(left_gutter)) + '+'
-        grid_name += str(int(width))
+            grid_name += unicode(int(left_gutter)) + '+'
+        grid_name += unicode(int(width))
         if right_gutter:
-            grid_name += '+' + str(int(right_gutter))
+            grid_name += '+' + unicode(int(right_gutter))
         if height and height > 1:
-            grid_name += 'x' + str(int(height))
+            grid_name += 'x' + unicode(int(height))
         key = (columns, grid_color, baseline_color, background_color)
         key = grid_name + '-' + base64.urlsafe_b64encode(hashlib.md5(repr(key)).digest()).rstrip('=').replace('-', '_')
         asset_file = key + '.png'
@@ -2759,7 +2759,7 @@ def _sprite_position(map, sprite, offset_x=None, offset_y=None):
     if sprite:
         x = None
         if offset_x is not None and not isinstance(offset_x, NumberValue):
-            x = str(offset_x)
+            x = unicode(offset_x)
         if x not in ('left', 'right', 'center'):
             if x:
                 offset_x = None
@@ -2768,7 +2768,7 @@ def _sprite_position(map, sprite, offset_x=None, offset_y=None):
                 x -= sprite[2]
         y = None
         if offset_y is not None and not isinstance(offset_y, NumberValue):
-            y = str(offset_y)
+            y = unicode(offset_y)
         if y not in ('top', 'bottom', 'center'):
             if y:
                 offset_y = None
@@ -3312,7 +3312,7 @@ def _headers(frm=None, to=None):
             to = 6 if to is None else int(getattr(to, 'value', to))
         except ValueError:
             to = 6
-    ret = ['h' + str(i) for i in range(frm, to + 1)]
+    ret = ['h' + unicode(i) for i in range(frm, to + 1)]
     ret = dict(enumerate(ret))
     ret['_'] = ','
     return ret
@@ -3335,7 +3335,7 @@ def _enumerate(prefix, frm, through, separator='-'):
     else:
         rev = lambda x: x
     if prefix:
-        ret = [prefix + separator + str(i) for i in rev(range(frm, through + 1))]
+        ret = [prefix + separator + unicode(i) for i in rev(range(frm, through + 1))]
     else:
         ret = [NumberValue(i) for i in rev(range(frm, through + 1))]
     ret = dict(enumerate(ret))
@@ -4242,7 +4242,7 @@ def call(name, args, R, is_function=True):
     _name = name.replace('_', '-')
     s = args and args.value.items() or []
     _args = [v for n, v in s if isinstance(n, int)]
-    _kwargs = dict((str(n[1:]).replace('-', '_'), v) for n, v in s if not isinstance(n, int) and n != '_')
+    _kwargs = dict((unicode(n[1:]).replace('-', '_'), v) for n, v in s if not isinstance(n, int) and n != '_')
     _fn_a = '%s:%d' % (_name, len(_args))
     #print >>sys.stderr, '#', _fn_a, _args, _kwargs
     _fn_n = '%s:n' % _name
@@ -4272,7 +4272,7 @@ def call(name, args, R, is_function=True):
             # Function not found, simply write it as a string:
             node = StringValue(name + '(' + _args + _kwargs + ')')
         else:
-            node = StringValue((sp + ' ').join(str(v) for n, v in s if n != '_'))
+            node = StringValue((sp + ' ').join(unicode(v) for n, v in s if n != '_'))
     return node
 
 


### PR DESCRIPTION
Two changesets: One to update radial-gradient and linear-gradient to use WebKit's new gradient syntax. The old WebKit syntax is preserved in owg, which Compass uses in it's CSS3 module. The second is to use unicode() instead of str() to handle cases where people use Unicode, especially for things such as content:
