### PR TITLE
Added suffix option for CSS files generated via watch

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -5976,6 +5976,8 @@ def main():
                       help="Also watch directories inside of the watch directory")
     parser.add_option("-o", "--output", metavar="PATH",
                       help="Write output to PATH (a directory if using watch, a file otherwise)")
+    parser.add_option("-s", "--suffix", metavar="STRING",
+                      help="If using watch, a suffix added to the output filename (i.e. filename.STRING.css)")
     parser.add_option("--time", action="store_true",
                       help="Display compliation times")
     parser.add_option("-t", "--test", action="store_true", help=SUPPRESS_HELP)
@@ -6163,6 +6165,7 @@ def main():
                 self.css = Scss()
                 self.css.scss_opts['compress'] = options.compress
                 self.output = options.output
+                self.suffix = options.suffix
 
             def is_valid(self, path):
                 return os.path.isfile(path) and path.endswith(".scss") and not os.path.basename(path).startswith("_")
@@ -6179,7 +6182,10 @@ def main():
             def compile(self, src_path):
                 fname = os.path.basename(src_path)
                 if fname.endswith(".scss"):
-                    fname = fname[:-5] + ".css"
+                    fname = fname[:-5]
+                    if self.suffix:
+                        fname += "." + self.suffix
+                    fname += ".css"
                 else:
                     # you didn't give me a file of the correct type!
                     return False


### PR DESCRIPTION
If provided (and using watch), the suffix option will append a custom suffix to all compiled CSS files. This is useful for excluding compiled CSS files from version control (e.g. ignoring *.compiled.css).
