### PR TITLE
Css functions improvements

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -402,7 +402,40 @@ _has_code_re = re.compile('''
     )
 ''', re.VERBOSE)
 
-_css_function_re = re.compile(r'^(from|to|mask|rotate|scale|format|local|url|attr|counter|counters|color-stop|rect|-[^-]+-.+)$')
+FUNCTIONS_CSS2 = 'attr counter counters url rgb rect'
+## CSS3
+FUNCTIONS_UNITS = 'calc min max cycle' # http://www.w3.org/TR/css3-values/
+FUNCTIONS_COLORS = 'rgba hsl hsla' # http://www.w3.org/TR/css3-color/
+FUNCTIONS_FONTS = 'local format' # http://www.w3.org/TR/css3-fonts/
+# http://www.w3.org/TR/css3-images
+FUNCTIONS_IMAGES = 'image element linear-gradient radial-gradient '\
+                   'repeating-linear-gradient repeating-radial-gradient'
+# http://www.w3.org/TR/css3-2d-transforms/
+FUNCTIONS_2D = 'matrix translate translateX translateY scale '\
+               'scaleX scaleY rotate skewX skewY'
+# http://www.w3.org/TR/css3-3d-transforms/
+FUNCTIONS_3D = 'matrix3d translate3d translateZ scale3d scaleZ rotate3d '\
+               'rotateX rotateY rotateZ perspective'
+# http://www.w3.org/TR/css3-transitions/
+FUNCTIONS_TRANSITIONS = 'cubic-bezier'
+# http://www.w3.org/TR/css3-animations/
+FUNCTIONS_ANIMATIONS = '' # has 'from' and 'to' block selectors, but no new function
+
+VENDORS = '-[^-]+-.+'
+
+_css_functions_re = re.compile(r'^(%s)$' % (
+    '|'.join(' '.join([
+        FUNCTIONS_CSS2,
+        FUNCTIONS_UNITS,
+        FUNCTIONS_COLORS,
+        FUNCTIONS_FONTS,
+        FUNCTIONS_IMAGES,
+        FUNCTIONS_2D,
+        FUNCTIONS_3D,
+        FUNCTIONS_TRANSITIONS,
+        FUNCTIONS_ANIMATIONS,
+        VENDORS
+    ]).split())))
 
 FILEID = 0
 POSITION = 1


### PR DESCRIPTION
- Uses a generic pattern for vendor prefixes, [the CSS2.1 spec lists 14 prefixes fitting the pattern](http://www.w3.org/TR/CSS21/syndata.html#vendor-keywords) and there are probably others, no point in enumerating them all.
- Splits the CSS functions into sections (per spec/module) and tries to expand the support base. Additions to this set should be easier and cleaner. I went through a bunch of "big"/well-known CSS3 specs, but I've probably missed both specs and functions within the current specs.

(I used spaces as a separator because I'm kinda lazy, using pipes would avoid a round of split/join though I'm not sure it's worth the loss in readability. YMMV)
