### PR TITLE
Quote StringValues with single quotes, as in QuotedStringValue.__str__

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -4500,7 +4500,7 @@ class QuotedStringValue(Value):
 
 class StringValue(QuotedStringValue):
     def __str__(self):
-        return self.value
+        return "'%s'" % escape(self.value)
 
     def __add__(self, other):
         if isinstance(other, ListValue):


### PR DESCRIPTION
CSS such as this

``` css
div {
  label: 'a b';
}
```

was being compiled to this

``` css
div{label:a b}
```

when this

``` css
div{label:'a b'}
```

is what was intended.
