### PR TITLE
Properly report when PIL is missing when processing inline images

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -3130,7 +3130,7 @@ def _inline_font_files(*args):
 
 
 def __image_url(path, only_path=False, cache_buster=True, dst_color=None, src_color=None, inline=False, mime_type=None):
-    if src_color and dst_color:
+    if src_color and dst_color or inline:
         if not Image:
             raise Exception("Images manipulation require PIL")
     filepath = StringValue(path).value


### PR DESCRIPTION
Otherwise it's harder than necessary to figure out why inline images don't work.
