### PR TITLE
fixed an issue that stoped sprites from working

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -2708,6 +2708,8 @@ def _sprite_map(g, **kwargs):
         key = list(zip(*files)[0]) + times + [repr(kwargs)]
         key = map_name + '-' + base64.urlsafe_b64encode(hashlib.md5(repr(key)).digest()).rstrip('=').replace('-', '_')
         asset_file = key + '.png'
+        if not os.path.exists(ASSETS_ROOT):
+            os.makedirs(ASSETS_ROOT)
         asset_path = os.path.join(ASSETS_ROOT, asset_file)
 
         if os.path.exists(asset_path + '.cache'):


### PR DESCRIPTION
Fixed an issue where image file-path's that came from sprite-file where
looking as absolute to os.path.join and thus fail to get the size.
