### PR TITLE
Allow absolute URLs in inline-image.

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -3258,6 +3258,8 @@ def __image_url(path, only_path=False, cache_buster=True, dst_color=None, src_co
         except:
             filetime = 'NA'
     else:
+        if filepath.startswith('/'):
+            filepath = filepath[1:]
         _path = os.path.join(STATIC_ROOT, filepath)
         if os.path.exists(_path):
             filetime = int(os.path.getmtime(_path))


### PR DESCRIPTION
This change makes SCSS code that looks like this work.

``` scss
url: inline-image("/path/to/image");
```

I hope that you will consider merging it, and I'm open to feedback on improving the change so it can get merged.

Thank you so much!
