### PR TITLE
fix bad decorator call (print_timing) by using *args and **kwargs

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -490,16 +490,16 @@ def spawn_rule(rule=None, **kwargs):
 def print_timing(level=0):
     def _print_timing(func):
         if VERBOSITY:
-            def wrapper(*arg):
+            def wrapper(*args, **kwargs):
                 if VERBOSITY >= level:
                     t1 = time.time()
-                    res = func(*arg)
+                    res = func(*args, **kwargs)
                     t2 = time.time()
                     profiling.setdefault(func.func_name, 0)
                     profiling[func.func_name] += (t2 - t1)
                     return res
                 else:
-                    return func(*arg)
+                    return func(*args, **kwargs)
             return wrapper
         else:
             return func


### PR DESCRIPTION
When trying the django example with file compilation there is an error about a wrapper function :

``` python
>>> import scss
Scanning acceleration disabled (_speedups not found)!
>>> scss.Scss().compile(scss_file='base.css.scss')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: wrapper() got an unexpected keyword argument 'scss_file'
```

This is caused by the `print_timing` decorator, the `wrapper` function does not accept `**kwargs` so it will fail dealing with the `scss_file='base.css.scss'.

This is fixed here, I also changed `*arg` for `*args` which is more "standard".

PS: This problem was reported in issue #42 as well.
