### PR TITLE
Allow load_paths to be specified on initialisation

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -1258,6 +1258,8 @@ class Scss(object):
                         else:
                             load_path_list = LOAD_PATHS  # New style
 
+                        load_path_list.extend(self._scss_opts['load_paths'] if self._scss_opts and self._scss_opts.has_key('load_paths') else [])
+
                         for path in ['./'] + load_path_list:
                             for basepath in ['./', os.path.dirname(rule[PATH])]:
                                 i_codestr = None
@@ -1735,6 +1737,7 @@ class Scss(object):
         """
         Generate the final CSS string
         """
+        
         if fileid:
             rules = self._rules.get(fileid) or []
         else:


### PR DESCRIPTION
Adding a list of load_paths to scss_opts when initialising an Scss
instance witll extend the current load path list with them
