### PR TITLE
Make pyScss compatible again with python 2.5.

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -1782,11 +1782,11 @@ class Scss(object):
         old_media = None
         old_property = None
 
-        try:
+        TextWrapper.wordsep_re = re.compile(r'(?<=,)(\s*)')
+        if hasattr(TextWrapper, 'wordsep_simple_re'):
             wrap = textwrap.TextWrapper(break_long_words=False, break_on_hyphens=False)
-        except TypeError:
+        else:
             wrap = textwrap.TextWrapper(break_long_words=False)
-        wrap.wordsep_re = re.compile(r'(?<=,)(\s*)')
         wrap = wrap.wrap
 
         total_rules = 0


### PR DESCRIPTION
The change introduced in changeset 4da61e4 broke the compilation of scss files with Python 2.5 : the parameter 'break_on_hyphens' of  textwrap.TextWrapper() constructor has been added in Python 2.6.

However, the readme claims as requirement "python >= 2.5".

Another solution would be to remove completely support for python 2.5.

_On a sidenote_: I maintain (when I have some time) to maintain the extension Flask-Scss that uses pyScss as its compilation engine, and as Flask supports python 2.5, I am required to support it too, which motivates this request.
