### PR TITLE
Fix and test for issue #154 (dividing numbers of the same unit type)

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -4460,6 +4460,10 @@ class NumberValue(Value):
                 first.value /= 100.0
             elif second_unit == '%' and first_unit != '%':
                 second = NumberValue(first) * second.value
+        elif op == operator.__div__:
+            if first_unit and first_unit == second_unit:
+                first.units = {}
+                second.units = {}
 
         val = op(first.value, second.value)
 

--- a/scss/tests.rst
+++ b/scss/tests.rst
@@ -301,6 +301,23 @@ http://xcss.antpaw.org/docs/syntax/math
     >>> print css.compile('''
     ... @option compress:no, short_colors:yes, reverse_colors:yes;
     ... .selector {
+    ...     padding: [4em / 2em];
+    ...     margin: [4em / 2em]em;
+    ...     width: [8px / 2px];
+    ...     height: [500px / 2];
+    ... }
+    ... ''') #doctest: +NORMALIZE_WHITESPACE
+    .selector {
+        padding: 2;
+        margin: 2em;
+        width: 4;
+        height: 250px;
+    }
+    
+
+    >>> print css.compile('''
+    ... @option compress:no, short_colors:yes, reverse_colors:yes;
+    ... .selector {
     ...     padding: [5em - 3em + 5px]px;
     ...     margin: [20 - 10] [30% - 10];
     ... }


### PR DESCRIPTION
Dividing two numbers of the same unit type now returns a value with no unit, to match ruby sass functionality.

This doesn't address the differences between pyscss and ruby sass when dividing by a number of a different unit type. The expected result for that is unclear, so should probably be left as is - ruby sass tends to raise an error when trying to do this, but they don't document or test that anywhere, so it may be a bug at their end.
