### PR TITLE
add register_function to allow user to extend available scss functions

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -5057,6 +5057,10 @@ fnct = {
 for u in _units:
     fnct[u + ':2'] = _convert_to
 
+def register_function(name, argc, fn):
+    if (isinstance(argc, int) and argc < 0) or (not isinstance(argc, int) and argc != 'n'):
+        raise Exception('argc must be 0, a positive int or the letter n')
+    fnct['%s:%s' % (name, argc)] = fn
 
 def interpolate(var, rule):
     context = rule[CONTEXT]


### PR DESCRIPTION
thought it would be useful to modify the fnct map at runtime so that users can define their own functions.
i had need for this to add a few string related functions specific to my app, which would not be worthwhile including in pyScss itself.
