### PR TITLE
scss/__init__.py: raise RuntimeWarning instead of writing to sys.stderr when _speedups is not found

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -81,7 +81,11 @@ locate_blocks = None
 try:
     from scss._speedups import locate_blocks
 except ImportError:
-    sys.stderr.write("Scanning acceleration disabled (_speedups not found)!\n")
+    import warnings
+    warnings.warn(
+        "Scanning acceleration disabled (_speedups not found)!",
+        RuntimeWarning
+        )
     from scss._native import locate_blocks
 
 ################################################################################


### PR DESCRIPTION
It seems like the Pythonic way to handle import warnings is using the warnings module.

This pull request addresses issue #83 by raising a RuntimeWarning instead of writing to sys.stderr. This means that an warning is generally still presented to the user on import, but that the importer may choose how those warnings are displayed. With the current implementation, for instance, pyScss will write to stderr during uWSGI's import of a WSGI application that uses pyScss. Not a good thing.
