### PR TITLE
Remove shebangs for scss_meta and __init__

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #-*- coding: utf-8 -*-
 """
 pyScss, a Scss compiler for Python

--- a/scss/scss_meta.py
+++ b/scss/scss_meta.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #-*- coding: utf-8 -*-
 """
 pyScss, a Scss compiler for Python


### PR DESCRIPTION
These shebangs should be removed: they are not supposed to be executed directly.
