### PR TITLE
clean up unused placeholder selectors

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -1405,6 +1405,8 @@ class Scss(object):
                                 more_parent_selectors))
                         rule_dependencies[parent_rule].append(rule_order[rule])
 
+        # clean up placeholder only rules
+        self.rules = [rule for rule in self.rules if not rule.is_pure_placeholder]
         self.rules.sort(key=lambda rule: min(rule_dependencies[rule]))
 
     @print_timing(3)

--- a/scss/rule.py
+++ b/scss/rule.py
@@ -316,6 +316,17 @@ class SassRule(object):
 
         return True
 
+    @property
+    def is_pure_placeholder(self):
+        selectors = self.selectors
+        if not selectors:
+            return False
+        for s in selectors:
+            if not s.has_placeholder:
+                return False
+        return True 
+
+
     def copy(self):
         return type(self)(
             source_file=self.source_file,

--- a/scss/tests/files/original-doctests/024-extend-placeholder.scss
+++ b/scss/tests/files/original-doctests/024-extend-placeholder.scss
@@ -5,4 +5,7 @@
   font-weight: bold;
   font-size: 2em;
 }
+%unused {
+  foo: bar;
+}
 .notice { @extend %extreme; }


### PR DESCRIPTION
see #245

The test case is already in `tests/from_ruby/test_extend.py`, that is `test_unused_placeholder_selector`
