### PR TITLE
make sure pseudo elements stick to the end when render

### DIFF
--- a/scss/selector.py
+++ b/scss/selector.py
@@ -62,6 +62,16 @@ TOKEN_TYPE_ORDER = {
 }
 TOKEN_SORT_KEY = lambda token: TOKEN_TYPE_ORDER.get(token[0], 0)
 
+PSEUDO_ELEMENTS = (
+    ':after',
+    ':before',
+    ':first-line',
+    ':first-letter',
+)
+# Psudo elements must go after any other simple selectors
+# ref: http://www.w3.org/TR/selectors/#pseudo-elements
+TOKEN_RENDER_SORT_KEY = lambda token: any([token.endswith(x) for x in PSEUDO_ELEMENTS])
+
 
 def _is_combinator_subset_of(specific, general, is_first=True):
     """Return whether `specific` matches a non-strict subset of what `general`
@@ -207,6 +217,7 @@ class SimpleSelector(object):
 
     def render(self):
         # TODO fail if there are no tokens, or if one is a placeholder?
+        self.tokens = sorted(self.tokens, key=TOKEN_RENDER_SORT_KEY)
         rendered = ''.join(self.tokens)
         if self.combinator != ' ':
             rendered = ' '.join((self.combinator, rendered))

--- a/scss/tests/files/original-doctests/037-test-7.css
+++ b/scss/tests/files/original-doctests/037-test-7.css
@@ -1,6 +1,9 @@
 a, #fake-links .link {
   color: blue;
 }
+a:after, #fake-links .link:after {
+  display: block;
+}
 a:hover, #fake-links :hover.link {
   text-decoration: underline;
 }

--- a/scss/tests/files/original-doctests/037-test-7.scss
+++ b/scss/tests/files/original-doctests/037-test-7.scss
@@ -3,5 +3,6 @@
 
 a {
   color: blue;
+  &:after {display: block}
   &:hover {text-decoration: underline}
 }


### PR DESCRIPTION
Don't know how to make an in place replacement for parent references when doing `@extend`,
but it is certain that pesudo element selectors should go after other selectors.

So here's a quick fix for #246
