### PR TITLE
grayscale(90%) is a CSS3 filter that should be left intact #157

### DIFF
--- a/scss/functions/core.py
+++ b/scss/functions/core.py
@@ -278,7 +278,7 @@ def grayscale(color):
     if isinstance(color, Number):
         # grayscale(n) and grayscale(n%) are CSS3 filters and should be left intact, but only                                                                                                                                                           
         # when using the "a" spelling                                                                                                                                                                                                                   
-        return String.unquoted("grayscale(%s)" % (color,))
+        return String.unquoted("grayscale(%s)" % (color.render(),))
     else:
         return greyscale(color)
 


### PR DESCRIPTION
grayscale(90%) is a CSS3 filter, and my valid css file returned an error while evaluating color.hsl (90.hsl)
