### PR TITLE
pyScss fails on UTF-8 data

### DIFF
--- a/scss/tests/test_misc.py
+++ b/scss/tests/test_misc.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 """Tests for miscellaneous features that should maybe be broken out into their
 own files, maybe.
 """
@@ -94,3 +95,13 @@ def test_extend_across_files():
 """
 
     assert expected == actual
+
+
+def test_unicode_files():
+    compiler = Scss()
+    unicode_input = u"""q {
+  quotes: "“" "”" "‘" "’";
+}"""
+    output = compiler.compile(unicode_input)
+
+    assert output == unicode_input


### PR DESCRIPTION
I checked using the ruby version, here's what it output:

```
$ sass /tmp/quotes.scss 
@charset "UTF-8";
q {
  quotes: "“" "”" "‘" "’"; }
```

The error that comes up is:

```
E             File "/XXX/pyScss/scss/expression.py", line 56, in do_glob_math
E               cont = str(cont)
E           UnicodeEncodeError: 'ascii' codec can't encode character u'\u201c' in position 1: ordinal not in range(128)
```

I could look into getting this test to pass, but right now I just don't have time.  I thought I'd open the pull request with just a failing test in case somebody else had time right now to look into it.
