### PR TITLE
fix crash from TypeError in compass support

### DIFF
--- a/scss/functions/compass/helpers.py
+++ b/scss/functions/compass/helpers.py
@@ -270,7 +270,7 @@ def elements_of_type(display):
     ret = _elements_of_type.get(d.value, None)
     if ret is None:
         raise Exception("Elements of type '%s' not found!" % d.value)
-    return List(ret, use_comma=True)
+    return List(map(String, ret), use_comma=True)
 
 
 @register('enumerate', 3)


### PR DESCRIPTION
Using django-pipeline with Compass I do

``` scss
@import "compass/reset";
```

which gives me a big fancy error message

``` python
SassEvaluationError: Error evaluating expression: elements-of-type(html5-block)
```

eventually ending in

```
.virtualenvs/project/lib/python2.7/site-packages/scss/types.py", line 563, in __init__ raise TypeError("Expected a Sass type, got %r" % (item,)) TypeError: Expected a Sass type, got 'article'
```

Drilling into the source code a bit shows that we are passing a list of normal python strings to the `List` constructor and it expects a list of `Value`s. All I'm doing is converting all of those CSS elements into `String`s before they get passed to the constructor which fixes the issue for me.
