### PR TITLE
radial-gradient problem.

### DIFF
--- a/scss/functions/compass/gradients.py
+++ b/scss/functions/compass/gradients.py
@@ -220,6 +220,9 @@ def radial_gradient(*args):
 
     position_and_angle = _get_gradient_position_and_angle(args)
     shape_and_size = _get_gradient_shape_and_size(args)
+    if position_and_angle == shape_and_size:
+        shape_and_size = None
+
     color_stops = _get_gradient_color_stops(args)
     if color_stops is None:
         raise Exception('No color stops provided to radial-gradient function')


### PR DESCRIPTION
When i using radial-gradient , in this way :

```
background: radial-gradient(circle at center , red 0%, green 100%)
```

produces: 

```
background: radial-gradient(circle at center, circle at center, red, green);
```

the problem is "circle at center, circle at center".
this is not working on opera > 12.0
