### PR TITLE
Modify tests to show Unicode handling regression

### DIFF
--- a/scss/tests/test_misc.py
+++ b/scss/tests/test_misc.py
@@ -101,6 +101,7 @@ def test_unicode_files():
     compiler = Scss(scss_opts=dict(style='expanded'))
     unicode_input = u"""q {
   quotes: "“" "”" "‘" "’";
+  content: "•";
 }
 """
     output = compiler.compile(unicode_input)


### PR DESCRIPTION
I'm creating this as a pull request instead of an issue so you can merge the change more easily if you want. With this change tests pass with native version but fail when speedups module is used (`u''` is returned).
