### PR TITLE
Allow disabling speedups

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -16,6 +16,9 @@ There's also an optional C speedup module, which requires having ``libpcre``
 and its development headers installed, with UTF-8 support enabled (which it is
 by default).
 
+When ``PYSCSS_DISABLE_SPEEDUPS`` environment variable is set when the package is
+imported speedup module will be disabled.
+
 
 Usage
 -----

--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -52,6 +52,7 @@ import glob
 from itertools import product
 import logging
 import warnings
+import os
 import os.path
 import re
 import sys
@@ -78,9 +79,16 @@ log = logging.getLogger(__name__)
 
 ################################################################################
 # Load C acceleration modules
-try:
-    from scss._speedups import locate_blocks
-except ImportError:
+
+locate_blocks = None
+
+if 'PYSCSS_DISABLE_SPEEDUPS' not in os.environ:
+    try:
+        from scss._speedups import locate_blocks
+    except ImportError:
+        pass
+
+if not locate_blocks:
     from scss._native import locate_blocks
 
 ################################################################################


### PR DESCRIPTION
It's very useful to disable speedups on demand, especially when speedup version seems less reliable than the native one (see https://github.com/Kronuz/pyScss/pull/294).
