### PR TITLE
Make an earier copy of the rules to close up the window for concurrent modification to break things.

### DIFF
--- a/scss/__init__.py
+++ b/scss/__init__.py
@@ -1330,10 +1330,11 @@ class Scss(object):
         # DEVIATION: These are used to rearrange rules in dependency order, so
         # an @extended parent appears in the output before a child.  Sass does
         # not do this, and the results may be unexpected.  Pending removal.
+        rules = list(self.rules)
         rule_order = dict()
         rule_dependencies = dict()
         order = 0
-        for rule in self.rules:
+        for rule in rules:
             rule_order[rule] = order
             # Rules are ultimately sorted by the earliest rule they must
             # *precede*, so every rule should "depend" on the next one
@@ -1347,7 +1348,7 @@ class Scss(object):
 
         # Now go through all the rules with an @extends and find their parent
         # rules.
-        for rule in self.rules:
+        for rule in rules:
             for selector in rule.extends_selectors:
                 # This is a little dirty.  intersection isn't a class method.
                 # Don't think about it too much.
@@ -1395,7 +1396,8 @@ class Scss(object):
                                 more_parent_selectors))
                         rule_dependencies[parent_rule].append(rule_order[rule])
 
-        self.rules.sort(key=lambda rule: min(rule_dependencies[rule]))
+        rules.sort(key=lambda rule: min(rule_dependencies[rule]))
+        self.rules = rules
 
     @print_timing(3)
     def parse_properties(self):


### PR DESCRIPTION
we've recently picked switched to SCSS in openstack Horizon and we are seeing some intermittent scss compile failures:  https://bugs.launchpad.net/horizon/+bug/1345955.  We think it's related to multiple threads attempting to compile the same scss files.

We are exploring ways to avoid the multithreading altogether, but it seems to me much safer if the compilation just worked.  It seems that the compiler "apply_extends" method breaks if multiple threads run through it; but the fix seems as easy as just making a copy of self.rules at the start of the method, process the copy and set it back at the end.

Sharing my prototype code that fixes the problem in my dev environment.
