### PR TITLE
restored running tests by typing 'tox'

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pytest
 setenv =
     PYTHONPATH = {toxinidir}
-commands = {toxworkdir}/{envname}/Scripts/py.test []
+commands = {toxworkdir}/{envname}/bin/py.test []
 
 
 [testenv:py26]


### PR DESCRIPTION
When running 'tox' from the command line it was failing because it couldnt find Scripts/py.test.   Changed the command to allow tests to run.