### PR TITLE
Increases parity of str-slice with Sass str-slice

### DIFF
--- a/scss/extension/core.py
+++ b/scss/extension/core.py
@@ -576,9 +576,13 @@ def str_index(string, substring):
 def str_slice(string, start_at, end_at=None):
     expect_type(string, String)
     expect_type(start_at, Number, unit=None)
-    py_start_at = start_at.to_python_index(len(string.value))
 
-    if end_at is None:
+    if int(start_at) == 0:
+        py_start_at = 1
+    else:
+        py_start_at = start_at.to_python_index(len(string.value))
+
+    if end_at is None or int(end_at) > len(string):
         py_end_at = None
     else:
         expect_type(end_at, Number, unit=None)

--- a/scss/extension/core.py
+++ b/scss/extension/core.py
@@ -578,11 +578,11 @@ def str_slice(string, start_at, end_at=None):
     expect_type(start_at, Number, unit=None)
 
     if int(start_at) == 0:
-        py_start_at = 1
+        py_start_at = 0
     else:
         py_start_at = start_at.to_python_index(len(string.value))
 
-    if end_at is None or int(end_at) > len(string):
+    if end_at is None or int(end_at) > len(string.value):
         py_end_at = None
     else:
         expect_type(end_at, Number, unit=None)

--- a/scss/tests/extension/test_core.py
+++ b/scss/tests/extension/test_core.py
@@ -277,6 +277,9 @@ def test_str_slice():
     assert calc('str-slice("abcd", 2)') == calc('"bcd"')
     assert calc('str-slice("abcd", -3, -2)') == calc('"bc"')
     assert calc('str-slice("abcd", 2, -2)') == calc('"bc"')
+    assert calc('str-slice("abcd", 0, 3)') == calc('"abc"')
+    assert calc('str-slice("abcd", 1, 3)') == calc('"abc"')
+    assert calc('str-slice("abcd", 1, 30)') == calc('"abcd"')
 
 
 def test_to_upper_case():


### PR DESCRIPTION
relates to issue #338
When using str-slice the compiler should correct for out of 
bounds or index zero, like ruby Sass.
This is also essential for use with the Bourbon library 
as of 4.2.3 and its implementation of is-length,
which is handled perfectly fine by Ruby Sass.