### PR TITLE
Switch from pathlib to pathlib2

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,10 @@ from __future__ import division
 from __future__ import print_function
 
 import logging
-from pathlib import Path
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 
 import pytest
 

--- a/scss/compiler.py
+++ b/scss/compiler.py
@@ -6,7 +6,10 @@ from __future__ import division
 from collections import defaultdict
 from enum import Enum
 import logging
-from pathlib import Path
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 import re
 import sys
 import warnings

--- a/scss/extension/core.py
+++ b/scss/extension/core.py
@@ -7,7 +7,10 @@ from __future__ import unicode_literals
 from itertools import product
 import math
 import os.path
-from pathlib import PurePosixPath
+try:
+    from pathlib import PurePosixPath
+except ImportError:
+    from pathlib2 import PurePosixPath
 
 from six.moves import xrange
 

--- a/scss/legacy.py
+++ b/scss/legacy.py
@@ -4,7 +4,10 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import os
-from pathlib import Path
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 from collections import namedtuple
 
 import six

--- a/scss/source.py
+++ b/scss/source.py
@@ -5,7 +5,10 @@ from __future__ import division
 
 import hashlib
 import logging
-from pathlib import Path
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 import re
 
 import six

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open('scss/scss_meta.py', 'rb') as f:
 install_requires = ['six']
 if sys.version_info < (3, 4):
     install_requires.append('enum34')
-    install_requires.append('pathlib')
+    install_requires.append('pathlib2')
 if sys.version_info < (2, 7):
     install_requires.append('ordereddict')
 


### PR DESCRIPTION
The pathlib backport module is no longer maintained. The development
has moved to the pathlib2 module instead.

Quoting from the pathlib's README:
"Attention: this backport module isn't maintained anymore. If you want
to report issues or contribute patches, please consider the pathlib2
project instead."
