### PR TITLE
Add meta-information that this package is not "zip_safe"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ def run_setup(with_binary):
         author=AUTHOR,
         author_email=AUTHOR_EMAIL,
         url=URL,
+        zip_safe=False,
         download_url=DOWNLOAD_URL,
         license=LICENSE,
         keywords='css oocss xcss sass scss less precompiler',


### PR DESCRIPTION
This module contains binary shared-library code and thus cannot be used as a
zip file.

This should fix #367 
