### PR TITLE
Drop Python 2.7, add 3.6+ for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 docs/_build/
 *_flymake*
 .sass-cache
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
 language: python
 python:
-    - "2.6"
-    - "2.7"
-    - "3.3"
-    - "3.4"
-    - "3.5"
-    - pypy
-    - pypy3
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7-dev"
+  - pypy
+  - pypy3
 install:
-    - pip install .
-    - pip install pillow pytest-cov coveralls
+  - pip install .
+  - pip install pillow pytest-cov coveralls
 script:
-    py.test --cov scss
+  py.test --cov scss
 after_success:
-    coveralls
+  coveralls

--- a/README.rst
+++ b/README.rst
@@ -17,17 +17,23 @@ programming capabilities and some other syntactic sugar.
 Quickstart
 ----------
 
-You need Python 2.6+ or 3.3+.  PyPy is also supported.
+You need Python 2.7 or 3.3+.  PyPy is also supported.
 
-Installation::
+Installation:
+
+.. code-block:: console
 
     pip install pyScss
 
-Usage::
+Usage:
+
+.. code-block:: console
 
     python -mscss < style.scss
 
-Python API::
+Python API:
+
+.. code-block:: python
 
     from scss import Compiler
     Compiler().compile_string("a { color: red + green; }")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,13 @@
 [tox]
-envlist = py26, py27, py33, py34, py35
+envlist =
+    py27
+    py33
+    py34
+    py35
+    py36
+    py37
+    pypy
+    pypy3
 
 [testenv]
 # fontforge bindings cannot be installed from pip, so they may only be
@@ -10,12 +18,6 @@ deps =
     six
     pytest
 commands = py.test {posargs:scss/tests}
-
-
-[testenv:py26]
-deps =
-    {[testenv]deps}
-    enum34
 
 [testenv:py27]
 deps =


### PR DESCRIPTION
- Drops Python 2.6, which is both EOL and failing on Travis CI
- Adds Python 3.6 and 3.7 to the test matrix (Tox and Travis CI)
- Uses `code-block` statements for code markup in the README