### PR TITLE
Fix "Possible nested set" warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
-    - "2.6"
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
+    - "3.6"
+    - "3.7"
     - pypy
     - pypy3
 install:

--- a/scss/selector.py
+++ b/scss/selector.py
@@ -33,7 +33,7 @@ SELECTOR_TOKENIZER = re.compile(r'''
 
     # Square brackets are attribute tests
     # TODO: this doesn't handle ] within a string
-    | [[] .+? []]
+    | [\[\] .+? \[\]]
 
     # Dot and pound start class/id selectors.  Percent starts a Sass
     # extend-target faux selector.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35
+envlist = py27, py34, py35, py36, py37
 
 [testenv]
 # fontforge bindings cannot be installed from pip, so they may only be
@@ -12,17 +12,7 @@ deps =
 commands = py.test {posargs:scss/tests}
 
 
-[testenv:py26]
-deps =
-    {[testenv]deps}
-    enum34
-
 [testenv:py27]
-deps =
-    {[testenv]deps}
-    enum34
-
-[testenv:py33]
 deps =
     {[testenv]deps}
     enum34


### PR DESCRIPTION
regex in python3.7 has changed slightly, and as a result using pyScss will result in the following warning:

    scss/selector.py:54: FutureWarning: Possible nested set at position 329

This PR fixes this by explicitly escaping the [] in question.