### PR TITLE
make it work with setuptools v46

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 import platform
 import sys
 
-from setuptools import setup, Extension, Feature
+from setuptools import setup, Extension
 
 # this imports PROJECT, URL, VERSION, AUTHOR, AUTHOR_EMAIL, LICENSE,
 # DOWNLOAD_URL
@@ -24,19 +24,19 @@ if sys.version_info < (2, 7):
 # fail safe compilation shamelessly stolen from the simplejson
 # setup.py file.  Original author: Bob Ippolito
 
-speedups = Feature(
-    'optional C speed-enhancement module',
-    standard=True,
-    ext_modules=[
-        # NOTE: header files are included by MANIFEST.in; Extension does not
-        # include headers in an sdist (since they're typically in /usr/lib)
-        Extension(
-            'scss.grammar._scanner',
-            sources=['scss/src/_speedups.c', 'scss/src/block_locator.c', 'scss/src/scanner.c', 'scss/src/hashtable.c'],
-            libraries=['pcre']
-        ),
-    ],
-)
+ext_modules = [
+    # NOTE: header files are included by MANIFEST.in; Extension does not
+    # include headers in an sdist (since they're typically in /usr/lib)
+    Extension(
+        'scss.grammar._scanner',
+        sources=['scss/src/_speedups.c', 'scss/src/block_locator.c',
+                 'scss/src/scanner.c', 'scss/src/hashtable.c'],
+        libraries=['pcre']
+    ),
+]
+
+extra_opts = {}
+extra_opts['ext_modules'] = ext_modules
 
 ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
 if sys.platform == 'win32' and sys.version_info > (2, 6):
@@ -83,9 +83,6 @@ def read(fname):
 
 
 def run_setup(with_binary):
-    features = {}
-    if with_binary:
-        features['speedups'] = speedups
     setup(
         name=PROJECT,
         version=VERSION,
@@ -117,12 +114,12 @@ def run_setup(with_binary):
             'scss.grammar',
         ],
         cmdclass={'build_ext': ve_build_ext},
-        features=features,
         entry_points="""
         [console_scripts]
         pyscss = scss.tool:main
         less2scss = scss.less2scss:main
         """,
+        **extra_opts
     )
 
 


### PR DESCRIPTION
pyScss fails to install with setuptools v46 because of use of removed Feature feature.

This fixes the problem.