### PR TITLE
 Travis CI: enable ppc64le and s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ addons:
 arch:
   - arm64
   - amd64
-    #  - ppc64le
-    #  - s390x
+  - ppc64le
+  - s390x
 
 python:
     - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,11 @@ python:
     - "3.6"
     - "3.7"
     - "3.8"
-    - pypy3
 
-# there is no pypy3 for arm64 on Travis CI      
+# pypy3 is available only for amd64
 jobs:
-  exclude:
-    - arch: arm64
+  include:
+    - arch: amd64
       python: pypy3
 
 install:


### PR DESCRIPTION
Maybe those platforms are not so popular in OpenStack world but we can enable them for free then why not doing it.