### PR TITLE
Revert "Let the speedup block locator complain about surplus closing braces."

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,27 +1,21 @@
 pyScss, a Scss compiler for Python
 ==================================
 
-|build-status| |coverage|
-
-.. |build-status| image:: https://travis-ci.org/Kronuz/pyScss.svg?branch=master
-    :target: https://travis-ci.org/Kronuz/pyScss
-
-.. |coverage| image:: https://coveralls.io/repos/Kronuz/pyScss/badge.png
-    :target: https://coveralls.io/r/Kronuz/pyScss
-
-pyScss is a compiler for the `Sass`_ language, a superset of CSS3 that adds
+pyScss2 is a compiler for the `Sass`_ language, a superset of CSS3 that adds
 programming capabilities and some other syntactic sugar.
 
 .. _Sass: http://sass-lang.com/
 
+Originally it was forked from unmaintained https://github.com/Kronuz/pyScss.
+
 Quickstart
 ----------
 
-You need Python 2.6+ or 3.3+.  PyPy is also supported.
+You need Python 2.7+ or 3.3+.  PyPy is also supported.
 
 Installation::
 
-    pip install pyScss
+    pip install pyScss2
 
 Usage::
 
@@ -46,8 +40,7 @@ Further reading
 ---------------
 
 Documentation is in Sphinx.  You can build it yourself by running ``make html``
-from within the ``docs`` directory, or read it on RTD:
-http://pyscss.readthedocs.org/en/latest/
+from within the ``docs`` directory.
 
 The canonical syntax reference is part of the Ruby Sass documentation:
 http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html
@@ -56,7 +49,7 @@ http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html
 Obligatory
 ----------
 
-Copyright © 2012 German M. Bravo (Kronuz).  Additional credits in the
+Copyright © 2020 Ivan Kolodyazhny (e0ne).  Additional credits in the
 documentation.
 
 Licensed under the `MIT license`_, reproduced in ``LICENSE``.

--- a/scss/scss_meta.py
+++ b/scss/scss_meta.py
@@ -46,7 +46,7 @@ from __future__ import unicode_literals
 
 import sys
 
-VERSION_INFO = (1, 0, 0)
+VERSION_INFO = (2, 0, 0)
 DATE_INFO = (2020, 3, 13)  # YEAR, MONTH, DAY
 VERSION = '.'.join(str(i) for i in VERSION_INFO)
 REVISION = '%04d%02d%02d' % DATE_INFO

--- a/scss/scss_meta.py
+++ b/scss/scss_meta.py
@@ -46,14 +46,14 @@ from __future__ import unicode_literals
 
 import sys
 
-VERSION_INFO = (1, 3, 5)
-DATE_INFO = (2016, 6, 8)  # YEAR, MONTH, DAY
+VERSION_INFO = (1, 0, 0)
+DATE_INFO = (2020, 3, 13)  # YEAR, MONTH, DAY
 VERSION = '.'.join(str(i) for i in VERSION_INFO)
 REVISION = '%04d%02d%02d' % DATE_INFO
-BUILD_INFO = "pyScss v" + VERSION + " (" + REVISION + ")"
-AUTHOR = "German M. Bravo (Kronuz)"
-AUTHOR_EMAIL = 'german.mb@gmail.com'
-URL = 'http://github.com/Kronuz/pyScss'
-DOWNLOAD_URL = 'http://github.com/Kronuz/pyScss/tarball/v' + VERSION
+BUILD_INFO = "pyScss2 v" + VERSION + " (" + REVISION + ")"
+AUTHOR = "Ivan Kolodyazhny (e0ne)"
+AUTHOR_EMAIL = 'e0ne@e0ne.info'
+URL = 'http://github.com/e0ne/pyScss'
+DOWNLOAD_URL = 'http://github.com/e0ne/pyScss/tarball/v' + VERSION
 LICENSE = "MIT"
-PROJECT = "pyScss"
+PROJECT = "pyScss2"

--- a/scss/src/block_locator.c
+++ b/scss/src/block_locator.c
@@ -398,12 +398,6 @@ BlockLocator_iternext(BlockLocator *self)
 		if (c == '\\') {
 			/* Start of an escape sequence; ignore next character */
 			self->codestr_ptr++;
-		} else if (c == '}' && self->depth == 0) {
-			self->block.error = -1;
-			sprintf(self->exc, "Unexpected closing brace on line %d", self->lineno);
-			#ifdef DEBUG
-				fprintf(stderr, "\t%s\n", self->exc);
-			#endif
 		}
 		/* only ASCII is special syntactically */
 		else if (c < 256) {

--- a/scss/src/scanner.c
+++ b/scss/src/scanner.c
@@ -107,11 +107,11 @@ Pattern_initialize(Pattern *patterns, int patterns_sz) {
 
 	for (i = 0; i < patterns_sz; i++) {
 		regex = Pattern_regex(patterns[i].tok, patterns[i].expr);
-		#ifdef DEBUG
 		if (regex) {
-			fprintf(stderr, "\tAdded regex pattern %s: %s\n", repr(regex->tok), repr(regex->expr));
+			#ifdef DEBUG
+				fprintf(stderr, "\tAdded regex pattern %s: %s\n", repr(regex->tok), repr(regex->expr));
+			#endif
 		}
-		#endif
 	}
 
 	Pattern_patterns_initialized = 1;

--- a/scss/src/utils.h
+++ b/scss/src/utils.h
@@ -7,10 +7,11 @@ PyMem_Strndup(const char *str, size_t len)
 {
 	if (str != NULL) {
 		char *copy = PyMem_New(char, len + 1);
-		if (copy != NULL)
+		if (copy != NULL) {
 			memcpy(copy, str, len);
 			copy[len] = '\0';
 			return copy;
+		}
 	}
 	return NULL;
 }

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 import platform
 import sys
 
-from setuptools import setup, Extension, Feature
+from setuptools import setup, Extension
 
 # this imports PROJECT, URL, VERSION, AUTHOR, AUTHOR_EMAIL, LICENSE,
 # DOWNLOAD_URL
@@ -24,19 +24,19 @@ if sys.version_info < (2, 7):
 # fail safe compilation shamelessly stolen from the simplejson
 # setup.py file.  Original author: Bob Ippolito
 
-speedups = Feature(
-    'optional C speed-enhancement module',
-    standard=True,
-    ext_modules=[
-        # NOTE: header files are included by MANIFEST.in; Extension does not
-        # include headers in an sdist (since they're typically in /usr/lib)
-        Extension(
-            'scss.grammar._scanner',
-            sources=['scss/src/_speedups.c', 'scss/src/block_locator.c', 'scss/src/scanner.c', 'scss/src/hashtable.c'],
-            libraries=['pcre']
-        ),
-    ],
-)
+ext_modules = [
+    # NOTE: header files are included by MANIFEST.in; Extension does not
+    # include headers in an sdist (since they're typically in /usr/lib)
+    Extension(
+        'scss.grammar._scanner',
+        sources=['scss/src/_speedups.c', 'scss/src/block_locator.c',
+                 'scss/src/scanner.c', 'scss/src/hashtable.c'],
+        libraries=['pcre']
+    ),
+]
+
+extra_opts = {}
+extra_opts['ext_modules'] = ext_modules
 
 ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
 if sys.platform == 'win32' and sys.version_info > (2, 6):
@@ -83,9 +83,6 @@ def read(fname):
 
 
 def run_setup(with_binary):
-    features = {}
-    if with_binary:
-        features['speedups'] = speedups
     setup(
         name=PROJECT,
         version=VERSION,
@@ -117,12 +114,12 @@ def run_setup(with_binary):
             'scss.grammar',
         ],
         cmdclass={'build_ext': ve_build_ext},
-        features=features,
         entry_points="""
         [console_scripts]
         pyscss = scss.tool:main
         less2scss = scss.less2scss:main
         """,
+        **extra_opts
     )
 
 


### PR DESCRIPTION
C extension has a bit different logic that Python implementation does.
Unfortunately, it fails on valid scss files. Let's revert commit
4cf0cb606ad32a04774a0a3ca9186e238bf61c1f until we'll figure out how to fix it
preperly with pyScc backward compatibility.