### PR TITLE
Revert "Let the speedup block locator complain about surplus closing"

### DIFF
--- a/scss/src/block_locator.c
+++ b/scss/src/block_locator.c
@@ -398,12 +398,6 @@ BlockLocator_iternext(BlockLocator *self)
 		if (c == '\\') {
 			/* Start of an escape sequence; ignore next character */
 			self->codestr_ptr++;
-		} else if (c == '}' && self->depth == 0) {
-			self->block.error = -1;
-			sprintf(self->exc, "Unexpected closing brace on line %d", self->lineno);
-			#ifdef DEBUG
-				fprintf(stderr, "\t%s\n", self->exc);
-			#endif
 		}
 		/* only ASCII is special syntactically */
 		else if (c < 256) {


### PR DESCRIPTION
Commit 4cf0cb606ad32a04774a0a3ca9186e238bf61c1f adds some
backward-incompatible changes to pyScss: not it fails on a valid
sass/scss filed. It means that Python and C implementation of parsers
are different.

This patch reverts the commit mentioned above to have the same
functionality between Python and C implementations.