### PR TITLE
Add selector-append function support

### DIFF
--- a/scss/extension/compass/helpers.py
+++ b/scss/extension/compass/helpers.py
@@ -220,6 +220,8 @@ def dash_o(*args):
 # ------------------------------------------------------------------------------
 # Selector generation
 
+# selector-append is a Sass function
+@ns.declare_alias('selector-append')
 @ns.declare
 def append_selector(selector, to_append):
     if isinstance(selector, List):


### PR DESCRIPTION
Sass selector-append function is the same as append-selector in compass
so we can just add teh alias for it.