### PR TITLE
Fix collections deprecation warning

### DIFF
--- a/scss/types.py
+++ b/scss/types.py
@@ -3,7 +3,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 import colorsys
 from fractions import Fraction
 import operator


### PR DESCRIPTION
Fixes:

```python
scss/types.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import Iterable
```