### PR TITLE
fix IE's rules limit - log as warning

### DIFF
--- a/scss/compiler.py
+++ b/scss/compiler.py
@@ -300,8 +300,8 @@ class Compilation(object):
         self.rules = self.apply_extends(self.rules)
 
         output, total_selectors = self.create_css(self.rules)
-        if total_selectors >= 4096:
-            log.error("Maximum number of supported selectors in Internet Explorer (4095) exceeded!")
+        if total_selectors > 65534:
+            log.warning("Maximum number of supported selectors in Internet Explorer (65534) exceeded!")
 
         return output
 


### PR DESCRIPTION
As far as I know [1] IE 11 supports 65534 rules.  BTW fix logging class from
error to warning [2].

[1] https://forums.asp.net/t/2059387.aspx?IE+10+and+11+CSS+Style+Sheet+Rules
[2] bdb02e8d Warning about IE 4095 maximum and improved debug_info
