### PR TITLE
Fix DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats

### DIFF
--- a/scss/src/_speedups.c
+++ b/scss/src/_speedups.c
@@ -8,6 +8,7 @@
 * MIT license (http://www.opensource.org/licenses/mit-license.php)
 * Copyright (c) 2011 German M. Bravo (Kronuz), All rights reserved.
 */
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include "py3defs.h"
 #include "block_locator.h"
@@ -22,7 +23,7 @@ typedef struct {
 } scss_BlockLocator;
 
 static char*
-scss_pyunicode_to_utf8(PyObject* obj, int* len)
+scss_pyunicode_to_utf8(PyObject* obj, Py_ssize_t* len)
 {
 	char* internal_buffer;
 	char* ret;
@@ -188,7 +189,8 @@ scss_Scanner_token(scss_Scanner *self, PyObject *args)
 	PyObject *py_token;
 
 	char *tok;
-	int token_num, len;
+	int token_num;
+	Py_ssize_t len;
 	PyObject *restrictions = NULL;
 	Hashtable *_restrictions = NULL;
 
@@ -272,7 +274,7 @@ static PyObject *
 scss_Scanner_reset(scss_Scanner *self, PyObject *args, PyObject *kwds)
 {
 	char *input = NULL;
-	int input_sz = 0;
+	Py_ssize_t input_sz = 0;
 
 	if (self->scanner != NULL) {
 		if (PyArg_ParseTuple(args, "|z#", &input, &input_sz)) {
@@ -289,11 +291,11 @@ scss_Scanner_setup_patterns(PyObject *self, PyObject *patterns)
 {
 	PyObject *item, *item0, *item1;
 	int i, is_tuple, _is_tuple;
-	long size;
+	Py_ssize_t size;
 
 	Pattern *_patterns = NULL;
 	int patterns_sz = 0;
-	int len;
+	Py_ssize_t len;
 	if (!Scanner_initialized()) {
 		is_tuple = PyTuple_Check(patterns);
 		if (is_tuple || PyList_Check(patterns)) {
@@ -325,17 +327,17 @@ scss_Scanner_init(scss_Scanner *self, PyObject *args, PyObject *kwds)
 {
 	PyObject *item, *item0, *item1;
 	int i, is_tuple, _is_tuple;
-	long size;
+	Py_ssize_t size;
 
 	PyObject *patterns, *ignore;
 	Pattern *_patterns = NULL;
 	int patterns_sz = 0;
-	int len;
+	Py_ssize_t len;
 	Pattern *_ignore = NULL;
 	int ignore_sz = 0;
 	PyObject *py_input = NULL;
 	char *encoded_input = NULL;
-	int encoded_input_sz = 0;
+	Py_ssize_t encoded_input_sz = 0;
 
 	self->scanner = NULL;
 

--- a/scss/src/scanner.c
+++ b/scss/src/scanner.c
@@ -8,6 +8,7 @@
 * MIT license (http://www.opensource.org/licenses/mit-license.php)
 * Copyright (c) 2011 German M. Bravo (Kronuz), All rights reserved.
 */
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include <stdio.h>
@@ -50,7 +51,7 @@ Pattern_regex(char *tok, char *expr) {
 }
 
 static int
-Pattern_match(Pattern *regex, char *string, int string_sz, int start_at, Token *p_token) {
+Pattern_match(Pattern *regex, char *string, Py_ssize_t string_sz, int start_at, Token *p_token) {
 	int options = PCRE_ANCHORED | PCRE_UTF8;
 	const char *errptr;
 	int ret, erroffset, ovector[3];
@@ -243,7 +244,7 @@ _Scanner_scan(Scanner *self, Hashtable *restrictions)
 /* Scanner public interface */
 
 void
-Scanner_reset(Scanner *self, char *input, int input_sz) {
+Scanner_reset(Scanner *self, char *input, Py_ssize_t input_sz) {
 	int i;
 
 	#ifdef DEBUG
@@ -290,7 +291,7 @@ Scanner_del(Scanner *self) {
 }
 
 Scanner*
-Scanner_new(Pattern patterns[], int patterns_sz, Pattern ignore[], int ignore_sz, char *input, int input_sz)
+Scanner_new(Pattern patterns[], int patterns_sz, Pattern ignore[], int ignore_sz, char *input, Py_ssize_t input_sz)
 {
 	int i;
 	size_t len;

--- a/scss/src/scanner.h
+++ b/scss/src/scanner.h
@@ -11,6 +11,9 @@
 #ifndef SCANNER_H
 #define SCANNER_H
 
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #include "hashtable.h"
 
 #define PCRE_STATIC
@@ -50,7 +53,7 @@ typedef struct {
 	int tokens_bsz;
 	Token *tokens;
 	Restriction *restrictions;
-	int input_sz;
+	Py_ssize_t input_sz;
 	char *input;
 	int pos;
 } Scanner;
@@ -59,8 +62,8 @@ int Scanner_initialized(void);
 void Scanner_initialize(Pattern *, int);
 void Scanner_finalize(void);
 
-void Scanner_reset(Scanner *self, char *input, int input_sz);
-Scanner *Scanner_new(Pattern *, int, Pattern *, int, char *, int);
+void Scanner_reset(Scanner *self, char *input, Py_ssize_t input_sz);
+Scanner *Scanner_new(Pattern *, int, Pattern *, int, char *, Py_ssize_t);
 void Scanner_del(Scanner *);
 
 Token* Scanner_token(Scanner *, int, Hashtable *restrictions);


### PR DESCRIPTION
We see the following warning when scss is used with python 3.8.
    
    scss/compiler.py:359: DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
       for c_lineno, c_property, c_codestr in locate_blocks(rule.unparsed_contents):
    
This warning was introduced by https://bugs.python.org/issue36381
to warn about an upcoming Python C API change.
The meaning of PY_SSIZE_T_CLEAN is described in
https://python.readthedocs.io/en/stable/c-api/arg.html#strings-and-buffers.
    
What we need to do are:

* find all usages of PyArg_Parse with # formats and related functions.
  Ensure that the type of the length argument is a Py_ssize_t.
* Add #define PY_SSIZE_T_CLEAN above the #include <Python.h>.
