### PR TITLE
Add support to Python 3.10

### DIFF
--- a/scss/types.py
+++ b/scss/types.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from collections import Iterable
+from collections.abc import Iterable
 import colorsys
 from fractions import Fraction
 import operator


### PR DESCRIPTION
Python 3.10 removed the aliases to collections.abc from the collections
module. See [1] for reference.

* Closes #422

[1] https://docs.python.org/3/whatsnew/3.10.html#removed

Signed-off-by: Athos Ribeiro <athos.ribeiro@canonical.com>