### PR TITLE
fix error: global flags not at the start of the expression at position 1

### DIFF
--- a/scss/grammar/expression.py
+++ b/scss/grammar/expression.py
@@ -86,7 +86,7 @@ class SassExpressionScanner(Scanner):
         ('VAR', '\\$[-a-zA-Z0-9_]+'),
         ('LITERAL_FUNCTION', '(-moz-calc|-webkit-calc|calc|expression|progid:[\\w.]+)(?=[(])'),
         ('ALPHA_FUNCTION', 'alpha(?=[(])'),
-        ('OPACITY', '((?i)opacity)'),
+        ('OPACITY', '(?i)(opacity)'),
         ('URL_FUNCTION', 'url(?=[(])'),
         ('IF_FUNCTION', 'if(?=[(])'),
         ('FNCT', '[-a-zA-Z_][-a-zA-Z0-9_]*(?=\\()'),


### PR DESCRIPTION
PyScss stopped working for python311.

From https://docs.python.org/3.11/whatsnew/3.11.html :

> In [re](https://docs.python.org/3.11/library/re.html#module-re) [Regular Expression Syntax](https://docs.python.org/3.11/library/re.html#re-syntax), global inline flags (e.g. (?i)) can now only be used at the start of regular expressions. Using them elsewhere has been deprecated since Python 3.6. (Contributed by Serhiy Storchaka in [bpo-47066](https://bugs.python.org/issue?@action=redirect&bpo=47066).)

The issue occurs in one pattern of the class ` scss.grammar.expression.SassExpressionScanner `.