### PR TITLE
Fix compatibility with Django 2.0

### DIFF
--- a/scss/util.py
+++ b/scss/util.py
@@ -240,7 +240,7 @@ class tmemoize(object):
 def getmtime(filename, storage=None):
     try:
         if storage:
-            d_obj = storage.modified_time(filename)
+            d_obj = storage.get_modified_time(filename)
             return int(time.mktime(d_obj.timetuple()))
         else:
             return int(os.path.getmtime(filename))


### PR DESCRIPTION
In Django 1.10, modified_time was deprecated in favor of get_modified_time and was removed in Django 2.0